### PR TITLE
Nodemailer config instead of object in config option

### DIFF
--- a/docs/_templates/about.html
+++ b/docs/_templates/about.html
@@ -3,7 +3,7 @@
 {% if theme_logo %}
 <p class="logo">
   <a href="{{ pathto(master_doc) }}">
-    <img class="logo" src="{{ pathto('_static/' ~ theme_logo, 1) }}" alt="Logo"/>
+    <img class="logo" src="{{ pathto('docs/_static/' ~ theme_logo, 1) }}" alt="Logo"/>
     {% if theme_logo_name|lower == 'true' %}
     <h1 class="logo logo-name">{{ project }}</h1>
     {% endif %}

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -7,7 +7,7 @@ Custom
 In production you should provide certain properties:
 
 * :any:`Config.graphiql`: desactivate the development IDE by setting this property to ``false``.
-* :any:`Config.mailTransporter`: provide an email configuration to send real emails to your users.
+* :any:`Config.nodemailerConfig`: provide a nodemailer configuration to send real emails to your users.
 * :any:`Config.mailFrom`: Define the sender address displayed in emails sent to users.
 * :any:`Config.host`: Public URL of the service. It will be used in emails sent to users to define for instance valid confirmation link.
 * :any:`Config.dbAddress`: Define the connection to a MongoDB database.
@@ -39,7 +39,7 @@ Example:
         graphiql: false,
         host: "https://my-service-public-adress.com",
         mailFrom: '"Foo Bar" <foo@bar.com>',
-        mailTransporter: nodemailer.createTransport({
+        nodemailerConfig: {
             host: "smtp.example.email",
             port: 465,
             secure: true,
@@ -47,7 +47,7 @@ Example:
             user: "FooBar",
             pass: "F@@8aR"
             }
-        }),
+        },
         dbAddress: "mongodb://login:password@something.mlab.com:19150/dbName",
         eventEmitter,
         privateKeyFilePath: './private-key.txt',

--- a/jam/bon.ts
+++ b/jam/bon.ts
@@ -3,7 +3,17 @@ import express from 'express';
 
 const app = express();
 
-app.use('/auth', kryptonAuth());
+app.use('/auth', kryptonAuth({ nodemailerConfig: {
+    from: '"NUSID Demo" <nusid.demo@gmail.com>',
+    host: 'smtp.gmail.com', // hostname 
+    secureConnection: true, // use SSL 
+    port: 465, // port for secure SMTP 
+    transportMethod: 'SMTP', // default is SMTP. Accepts anything that nodemailer acce$
+    auth: {
+        user: 'nusid.demo@gmail.com',
+        pass: 'nusid@pp'
+    }
+}}));
 
 app.listen(process.env.PORT || 5000, () => {
     console.log(`server is listening on ${process.env.PORT || 5000}`)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krypton-org/krypton-auth",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Express authentication middleware, using GraphQL and JSON Web Tokens.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,7 @@ import { EventEmitter } from 'events';
 import { Request } from 'express';
 import fs from 'fs';
 import { Algorithm } from 'jsonwebtoken';
-import { Transporter } from 'nodemailer';
+import { Transport } from 'nodemailer';
 import path from 'path';
 import SocketIO from 'socket.io';
 import Url from 'url-parse';
@@ -84,9 +84,9 @@ export interface Config {
      */
     mailFrom?: string | Address;
     /**
-     * A `Nodemailer transporter <https://nodemailer.com/smtp/#examples>`_ used to send administration emails to users. Create one by calling ``createTransport`` from the `Nodemailer API <https://nodemailer.com/smtp/#examples>`_. The default value is ``undefined``.
+     * A `Nodemailer configuration <https://nodemailer.com/smtp/#examples>`_ used to send administration emails to users. The default value is ``undefined``.
      * ::
-     *    const transporter = nodemailer.createTransport({
+     *    const nodemailerConfig = {
      *         host: "smtp.example.email",
      *         port: 587,
      *         secure: false, // true for 465, false for other ports
@@ -94,16 +94,16 @@ export interface Config {
      *             user: credentials.user,
      *             pass: credentials.pass
      *        }
-     *    });
+     *    };
      *
-     *    app.use('/auth', kryptonAuth({ transporter }));
+     *    app.use('/auth', kryptonAuth({ nodemailerConfig }));
      *
      * If left ``undefined`` a Nodemailer test account is set automatically. It will print URL links on the command line to let you preview the emails that would have normally been sent.
      * ::
      *     Message sent: <365ea109-f645-e3a1-5e08-48e4c8a37bcb@JohannC>
      *     Preview URL: https://ethereal.email/message/Xklk07cTigz7mlaKXkllHsRk0gyz7kuxAAAAAWLgnFDcJwUFl8MZ-h1shKs
      */
-    mailTransporter?: Transporter;
+    nodemailerConfig?: any;
     /**
      * The filepath to the `EJS <https://ejs.co/>`_ template file of notification page.
      * This library include a simple one located in `./nodes_module/krypton-auth/lib/templates/pages/Notification.ejs <https://github.com/JohannC/krypton-auth/blob/master/lib/templates/pages/Notification.ejs>`_.
@@ -199,7 +199,7 @@ export class DefaultConfig implements Config, ReadyStatus {
     public isAgendaReady: boolean = false;
     public isMongooseReady: boolean = false;
     public isTestEmailReady: boolean = false;
-    public mailTransporter: undefined;
+    public nodemailerConfig: any;
     public mailFrom: undefined;
     public notificationPageTemplate = path.resolve(__dirname, '../lib/templates/pages/Notification.ejs');
     public privateKey = undefined;
@@ -247,7 +247,7 @@ export class DefaultConfig implements Config, ReadyStatus {
             this.isTestEmailReady = true;
             console.log('Testing email credentials obtained \u2705');
         }
-        if (this.isAgendaReady && this.isMongooseReady && (this.mailTransporter || this.isTestEmailReady)) {
+        if (this.isAgendaReady && this.isMongooseReady && (this.nodemailerConfig || this.isTestEmailReady)) {
             console.log('Connection to MongoDB established \u2705');
             console.log('Krypton Authentication is ready \u2705');
             this.onReady();

--- a/src/controller/UserController.ts
+++ b/src/controller/UserController.ts
@@ -44,7 +44,7 @@ const isUserLoggedIn = (req: Request): boolean => req.user !== undefined;
  * @returns {boolean} true if a notificaiton should be sent to client with the preview link in case of a mock email
  */
 const isMockEmailAndClientCanReceivePreview = (req: Request): boolean => {
-    return !config.mailTransporter && config.graphiql && req.cookies.clientId;
+    return !config.nodemailerConfig && config.graphiql && req.cookies.clientId;
 };
 
 /**

--- a/src/jobs/email.ts
+++ b/src/jobs/email.ts
@@ -16,7 +16,7 @@ export default function(agenda: Agenda): void {
     agenda.define('email', async (job: Agenda.Job<Email>) => {
         try {
             const info = await send(job.attrs.data);
-            if (!config.mailTransporter) {
+            if (!config.nodemailerConfig) {
                 console.log('Message sent: %s', info.messageId);
                 console.log('Preview URL: %s', nodemailer.getTestMessageUrl(info));
                 const clientId = job.attrs.data.clientId;

--- a/src/mailer/Mailer.ts
+++ b/src/mailer/Mailer.ts
@@ -10,8 +10,8 @@ import { EmailNotSentError } from '../error/ErrorTypes';
 
 let transporter: Transporter;
 
-if (config.mailTransporter) {
-    transporter = config.mailTransporter;
+if (config.nodemailerConfig) {
+    transporter = nodemailer.createTransport(config.nodemailerConfig);
 } else {
     nodemailer.createTestAccount((err, account) => {
         config.serviceReady({ isTestEmailReady: true });

--- a/src/router/Router.ts
+++ b/src/router/Router.ts
@@ -46,7 +46,7 @@ router.get('/form/reset/password', UserController.resetPasswordForm);
 
 if (config.graphiql) {
     router.use('/', async (req: Request, res: Response, next: NextFunction) => {
-        if (!config.io && !config.mailTransporter) {
+        if (!config.io && !config.nodemailerConfig) {
             // @ts-ignore
             config.io = socketIo(req.socket.server);
             config.clientIdToSocket = new Map<string, SocketIO.Socket>();

--- a/test/integration/EmailTestAccount.test.ts
+++ b/test/integration/EmailTestAccount.test.ts
@@ -8,7 +8,7 @@ let request;
 beforeAll((done) => {
     appTester = new AppTester({
         dbAddress: "mongodb://localhost:27017/TestFakeEMailAccount",
-        mailTransporter: undefined,
+        nodemailerConfig: undefined,
         onReady: async () => {
             request = appTester.getRequestSender();
             done();

--- a/test/integration/EmittingEmailErrorEvents.test.ts
+++ b/test/integration/EmittingEmailErrorEvents.test.ts
@@ -17,7 +17,7 @@ let user = {
 beforeAll((done) => {
     appTester = new AppTester({
         dbAddress: "mongodb://localhost:27017/Logger",
-        mailTransporter: {
+        nodemailerConfig: {
             host: 'wrong',
             port: 587,
             auth: {

--- a/test/integration/RenderGraphiQLIDE.test.ts
+++ b/test/integration/RenderGraphiQLIDE.test.ts
@@ -20,7 +20,7 @@ test("Access GraphIQL IDE", async (done) => {
     done();
 });
 
-test('No IO Server set as mailTransporter provided', async (done) => {
+test('No IO Server set as nodemailerConfig provided', async (done) => {
     const config = require('../../src/config').default;
     let res = await request.get("/").set("Accept", "text/html");
     expect(res.statusCode).toBe(200);

--- a/test/utils/AppTester.ts
+++ b/test/utils/AppTester.ts
@@ -3,7 +3,6 @@ import request from 'supertest';
 import mongoose from 'mongoose';
 import express from 'express';
 import kryptonAuth from '../../src/index';
-import mailer, { Transporter } from 'nodemailer';
 import { parse } from 'cookie';
 
 
@@ -12,20 +11,20 @@ export default class AppTester {
     private enumSet: Set<string>;
 
     constructor(options) {
-        const mailTransporter: Transporter = mailer.createTransport({
+        const nodemailerConfig = {
             host: 'smtp.ethereal.email',
             port: 587,
             auth: {
                 user: 'x6z5n5ywx7wbpgkb@ethereal.email',
                 pass: 'JAXPXSY9MQP3uHtFjB'
             }
-        });
+        };
 
         this.enumSet = new Set<string>();
 
         options = {
             ...{
-                mailTransporter,
+                nodemailerConfig,
                 extendedSchema: {
                     firstName: {
                         type: String,


### PR DESCRIPTION
Service configuration change:
- `nodemailerConfig` replace `mailTransporter` option where it is now a nodemailer configuration that is passed and not an instantiated nodemailer object.