### PR TITLE
Change property verified to email_verified to respect JWT Claims

### DIFF
--- a/docs/queries.rst
+++ b/docs/queries.rst
@@ -46,7 +46,7 @@ You will be able to access private mutations/queries by including it in the ``Au
         expiryDate
         user {
           _id
-          verified
+          email_verified
         }
       }
     }
@@ -70,7 +70,7 @@ To access your own private data use the ``me`` query.  You have to be logged in 
     query {
       me {
         _id
-        verified
+        email_verified
         email
       }
     }
@@ -94,7 +94,7 @@ To change any of your user fields, use the ``updateMe`` mutation. You have to be
         expiryDate
         user {
           _id
-          verified
+          email_verified
         }
       }
     }
@@ -121,7 +121,7 @@ To change your password, use the ``updateMe`` mutation passing your ``previousPa
         expiryDate
         user {
           _id
-          verified
+          email_verified
         }
       }
     }

--- a/src/controller/UserController.ts
+++ b/src/controller/UserController.ts
@@ -109,8 +109,8 @@ export const confirmEmail = async (req: Request, res: Response, next: NextFuncti
             throw new UnauthorizedError('This link is no longer valid.');
         }
         const user = await User.getUser({ verificationToken: token });
-        await User.updateUser({ email: user.email }, { verificationToken: null, verified: true });
-        notifications.push({ type: 'success', message: 'You are now verified!' });
+        await User.updateUser({ email: user.email }, { verificationToken: null, email_verified: true });
+        notifications.push({ type: 'success', message: 'You are now email_verified!' });
     } catch (err) {
         notifications.push({ type: 'error', message: 'This link is not valid!' });
     } finally {
@@ -171,7 +171,7 @@ export const resendConfirmationEmail = async (req: Request): Promise<boolean> =>
         throw new UnauthorizedError('Please login!');
     }
     const user = await User.getUser({ _id: req.user._id });
-    if (user.verified) {
+    if (user.email_verified) {
         throw new EmailAlreadyConfirmedError('Your email adress has already been confirmed.');
     } else {
         let clientId;
@@ -253,9 +253,9 @@ export const updateUser = async (
     try {
         let isEmailVerified = true;
 
-        if (req.user.verified && userUpdates.email) {
+        if (req.user.email_verified && userUpdates.email) {
             userUpdates.verificationToken = generateToken(TOKEN_LENGTH);
-            userUpdates.verified = false;
+            userUpdates.email_verified = false;
             isEmailVerified = false;
         }
 

--- a/src/model/UserSchema.ts
+++ b/src/model/UserSchema.ts
@@ -59,7 +59,7 @@ const basicSchema = {
         isPublic: false,
         type: String,
     },
-    verified: {
+    email_verified: {
         default: false,
         isPublic: true,
         isUneditable: true,
@@ -85,7 +85,7 @@ const privateFields: string[] = Object.keys(UserSchema).filter(x => !UserSchema[
 const internalFields: string[] = Object.keys(UserSchema).filter(x => UserSchema[x].isInternal);
 
 /**
- * List of uneditable fields. Users can't change the value of those fields (like if the user is `verified`)
+ * List of uneditable fields. Users can't change the value of those fields (like if the user email is `verified`)
  */
 const uneditableFields: string[] = Object.keys(UserSchema).filter(x => UserSchema[x].isUneditable);
 

--- a/test/integration/ConfirmEmail.test.ts
+++ b/test/integration/ConfirmEmail.test.ts
@@ -53,10 +53,10 @@ test("Confirm email", async (done) => {
     
     
     const UserModel = require('../../src/model/UserModel').default;
-    const userRetrieved = await UserModel.getUser({email: user.email}, {verified: true});
+    const userRetrieved = await UserModel.getUser({email: user.email}, {email_verified: true});
     res = await request.get("/user/email/confirmation?token="+userRetrieved.verificationToken);
     expect(res.statusCode).toBe(200);
-    expect(res.text.includes("You are now verified")).toBeTruthy();
+    expect(res.text.includes("You are now email_verified")).toBeTruthy();
     done();
 });
 

--- a/test/integration/Login.test.ts
+++ b/test/integration/Login.test.ts
@@ -47,7 +47,7 @@ test('Login by email & query user data', async (done) => {
             user{
                 email
                 _id
-                verified
+                email_verified
                 age
                 receiveNewsletter
                 gender
@@ -64,7 +64,7 @@ test('Login by email & query user data', async (done) => {
     expect(typeof res.data.login.token === "string").toBeTruthy();
     expect(res.data.login.token.length > 10).toBeTruthy();
     expect(res.data.login.user.email).toBe(user.email);
-    expect(res.data.login.user.verified).toBe(false);
+    expect(res.data.login.user.email_verified).toBe(false);
     expect(res.data.login.user.age).toBe(user.age);
     expect(res.data.login.user.receiveNewsletter).toBe(user.receiveNewsletter);
     expect(res.data.login.user.gender).toBe(user.gender);
@@ -92,7 +92,7 @@ test('Login by email & decrypting token to get user data', async (done) => {
             expect(typeof userDecrypted._id === "string").toBeTruthy();
             expect(userDecrypted._id.length > 5).toBeTruthy();
             expect(userDecrypted.email).toBe(user.email);
-            expect(userDecrypted.verified).toBe(false);
+            expect(userDecrypted.email_verified).toBe(false);
             expect(userDecrypted.age).toBe(user.age);
             expect(userDecrypted.receiveNewsletter).toBe(user.receiveNewsletter);
             expect(userDecrypted.gender).toBe(user.gender);

--- a/test/integration/RecoverPassword.test.ts
+++ b/test/integration/RecoverPassword.test.ts
@@ -97,7 +97,7 @@ test("Change password with recovery token", async (done) => {
     let res = await request.getGraphQL(recoveryEmailQuery);
     expect(res.data.sendPasswordRecoveryEmail).toBeTruthy();
     const UserModel = require('../../src/model/UserModel').default;
-    const userRetrieved = await UserModel.getUser({ email: user.email }, { verified: true });
+    const userRetrieved = await UserModel.getUser({ email: user.email }, { email_verified: true });
     expect(typeof userRetrieved.passwordRecoveryToken === "string").toBeTruthy();
     expect(userRetrieved.passwordRecoveryToken.length > 10).toBeTruthy();
     let newPassword = "newPassword";

--- a/test/integration/UpdateMe.test.ts
+++ b/test/integration/UpdateMe.test.ts
@@ -99,7 +99,7 @@ test('Update usersname - email - password', async (done) => {
               token,
               expiryDate
               user{
-                verified
+                email_verified
                 _id
                 email
               }
@@ -129,7 +129,7 @@ test('Update usersname - email - password', async (done) => {
             expect(typeof userDecrypted._id === "string").toBeTruthy();
             expect(userDecrypted._id.length > 5).toBeTruthy();
             expect(userDecrypted.email).toBe(updates.email);
-            expect(userDecrypted.verified).toBe(false);
+            expect(userDecrypted.email_verified).toBe(false);
             expect(userDecrypted.age).toBe(user1.age);
             expect(userDecrypted.receiveNewsletter).toBe(user1.receiveNewsletter);
             expect(userDecrypted.gender).toBe(user1.gender);
@@ -222,9 +222,9 @@ test('Wrong gender', async (done) => {
     done();
 });
 
-test('Update email of a verified user', async (done) => {
+test('Update email of a email_verified user', async (done) => {
     const UserModel = require('../../src/model/UserModel').default;
-    await UserModel.updateUser({ email: user3.email }, { verified: true });
+    await UserModel.updateUser({ email: user3.email }, { email_verified: true });
     let loginRes = await appTester.login(user3.email, user3.password);
     token3 = loginRes.data.login.token;
     refreshToken3 = loginRes.cookies.refreshToken;
@@ -234,14 +234,14 @@ test('Update email of a verified user', async (done) => {
             updateMe(fields:{email: "${newEmail}"}){
               token
               user{
-                verified
+                email_verified
               }
             }
           }`
     }
 
     let updateRes = await request.postGraphQL(query, token3, refreshToken3);
-    expect(updateRes.data.updateMe.user.verified).toBeFalsy();
+    expect(updateRes.data.updateMe.user.email_verified).toBeFalsy();
 
     done();
 });

--- a/test/integration/WithUsername.test.ts
+++ b/test/integration/WithUsername.test.ts
@@ -162,7 +162,7 @@ test('Update usersname - email - password', async (done) => {
               expiryDate
               user{
                 username
-                verified
+                email_verified
                 _id
                 email
               }


### PR DESCRIPTION
Fix to the issue [53](https://github.com/krypton-org/krypton-auth/issues/53). The property `verified` telling if the user email has been confirmed is now named `email_verified` to respect [JSON Web Token Claims](https://www.iana.org/assignments/jwt/jwt.xhtml).